### PR TITLE
Moved callback for async path finish to after the task is fully cleaned up

### DIFF
--- a/Source/DonAINavigation/Private/DonNavigationManager.cpp
+++ b/Source/DonAINavigation/Private/DonNavigationManager.cpp
@@ -148,9 +148,8 @@ void ADonNavigationManager::ReceiveAsyncResults()
 	{
 		FDonNavigationQueryTask task;
 		CompletedNavigationTasks.Dequeue(task);
-		task.BroadcastResult();
-
 		ActiveNavigationTaskOwners.Remove(task.Data.Actor.Get());
+		task.BroadcastResult();
 
 #if DEBUG_DoNAI_THREADS
 		auto owner = task.Data.Actor.Get();


### PR DESCRIPTION
Hi there! Thanks so much for making this plugin -- it's been really great to work in!

In the current version of DoN, calling SchedulePathfindingTask from the Result Handler Delegate of an earlier SchedulePathfindingTask throws an error because the callback is invoked before the task is fully cleaned up. 

An example use case would be an actor that's iteratively querying paths to different targets in order to choose the best one to take. DoN only allows one active pathfinding task at a time, so this actor will need to schedule new tasks immediately as the old ones finish.

This case is tested to work after swapping these two lines of code!