### PR TITLE
Inner margin for ClampLocationNavigableWorld

### DIFF
--- a/Source/DonAINavigation/Classes/DonNavigationManager.h
+++ b/Source/DonAINavigation/Classes/DonNavigationManager.h
@@ -998,8 +998,8 @@ public:
 		return VolumeAtSafe(x, y, z);
 	}
 
-	/* Clamps a vector within the navigation bounds, as defined by the grid configuration of the navigation object you've placed in the map,
-	 *  brought in by a margin of InnerMarginOffset */
+	/** Clamps a vector within the navigation bounds, as defined by the grid configuration of the navigation object you've placed in the map,
+	 *   brought in by a margin of InnerMarginOffset when clamping downward to prevent rounding errors */
 	UFUNCTION(BlueprintPure, Category = "DoN Navigation")
 	FVector ClampLocationToNavigableWorld(FVector DesiredLocation, float InnerMarginOffset = 0.001f)
 	{
@@ -1007,11 +1007,11 @@ public:
 			return DesiredLocation;
 
 		FVector origin = GetActorLocation();
-		// We bring the clamped vector in by an extra innerMarginOffset cm. Necessary because VolumeIdAt does a float-to-int rounding, and thus clamping
-		//  to a max world dimension would otherwise round to an invalid index (e.g. rounding to index 100 instead of 99 in a 100-voxel world)
-		float xClamped = FMath::Clamp(DesiredLocation.X, origin.X + innerMarginOffset, origin.X + XGridSize * VoxelSize - innerMarginOffset);
-		float yClamped = FMath::Clamp(DesiredLocation.Y, origin.Y + innerMarginOffset, origin.Y + YGridSize * VoxelSize - innerMarginOffset);
-		float zClamped = FMath::Clamp(DesiredLocation.Z, origin.Z + innerMarginOffset, origin.Z + ZGridSize * VoxelSize - innerMarginOffset);
+		// When clamping down, bring the vector in by an extra InnerMarginOffset cm. Necessary because VolumeIdAt does a float-to-int rounding, and thus clamping
+		//  to a max world dimension would otherwise round to an invalid index (e.g. rounding 100.5 to invalid index 100 instead of 99 in a 100-voxel world)
+		float xClamped = FMath::Clamp(DesiredLocation.X, origin.X, origin.X + XGridSize * VoxelSize - InnerMarginOffset);
+		float yClamped = FMath::Clamp(DesiredLocation.Y, origin.Y, origin.Y + YGridSize * VoxelSize - InnerMarginOffset);
+		float zClamped = FMath::Clamp(DesiredLocation.Z, origin.Z, origin.Z + ZGridSize * VoxelSize - InnerMarginOffset);
 
 		return FVector(xClamped, yClamped, zClamped);
 	}

--- a/Source/DonAINavigation/Classes/DonNavigationManager.h
+++ b/Source/DonAINavigation/Classes/DonNavigationManager.h
@@ -998,17 +998,20 @@ public:
 		return VolumeAtSafe(x, y, z);
 	}
 
-	/* Clamps a vector to the navigation bounds as defined by the grid configuration of the navigation object you've placed in the map*/
+	/* Clamps a vector within the navigation bounds, as defined by the grid configuration of the navigation object you've placed in the map,
+	 *  brought in by a margin of InnerMarginOffset */
 	UFUNCTION(BlueprintPure, Category = "DoN Navigation")
-	FVector ClampLocationToNavigableWorld(FVector DesiredLocation)
+	FVector ClampLocationToNavigableWorld(FVector DesiredLocation, float InnerMarginOffset = 0.001f)
 	{
 		if (bIsUnbound)
 			return DesiredLocation;
 
 		FVector origin = GetActorLocation();
-		float xClamped = FMath::Clamp(DesiredLocation.X, origin.X, origin.X + XGridSize * VoxelSize);
-		float yClamped = FMath::Clamp(DesiredLocation.Y, origin.Y, origin.Y + YGridSize * VoxelSize);
-		float zClamped = FMath::Clamp(DesiredLocation.Z, origin.Z, origin.Z + ZGridSize * VoxelSize);
+		// We bring the clamped vector in by an extra innerMarginOffset cm. Necessary because VolumeIdAt does a float-to-int rounding, and thus clamping
+		//  to a max world dimension would otherwise round to an invalid index (e.g. rounding to index 100 instead of 99 in a 100-voxel world)
+		float xClamped = FMath::Clamp(DesiredLocation.X, origin.X + innerMarginOffset, origin.X + XGridSize * VoxelSize - innerMarginOffset);
+		float yClamped = FMath::Clamp(DesiredLocation.Y, origin.Y + innerMarginOffset, origin.Y + YGridSize * VoxelSize - innerMarginOffset);
+		float zClamped = FMath::Clamp(DesiredLocation.Z, origin.Z + innerMarginOffset, origin.Z + ZGridSize * VoxelSize - innerMarginOffset);
 
 		return FVector(xClamped, yClamped, zClamped);
 	}


### PR DESCRIPTION
This PR changes ClampLocationToNavigableWorld so that vector components with values greater than the max world edges are clamped to _just below_ the max values. For instance, the vector (150, 0, 0) is clamped to (99.9999, 0, 0) instead of (100, 0, 0) in a 100 centimeter world.

This was made in response to an engine crash I experienced after using ClampLocationToNavigableWorld to clean a location value before sending it into DoN. The engine crashed because VolumeAtId uses a float-to-int comparison in order to obtain a voxel address from a floating-point location, and the clamped value rounded to invalid index "100" in a 100-voxel world, whereas the valid indices ran from 0-99. 

With this in mind it seems that locations exactly along the maximum edges of a DoN world are not safe, and thus it makes sense to me that ClampLocationToNavigableWorld should clamp away from them.

Thank you for all your hard work on this plugin!