### PR TITLE
BTTask_FlyTo node accepts Actor targets

### DIFF
--- a/Source/DonAINavigation/Classes/BehaviorTree/BTTask_FlyTo.h
+++ b/Source/DonAINavigation/Classes/BehaviorTree/BTTask_FlyTo.h
@@ -61,6 +61,8 @@ struct FBT_FlyToTarget
 
 	FVector TargetLocation;
 
+	AActor* TargetActor;
+
 	FDelegateHandle BBObserverDelegateHandle;
 
 	uint32 bTargetLocationChanged : 1;
@@ -73,6 +75,7 @@ struct FBT_FlyToTarget
 		Metadata = FBT_FlyToTarget_Metadata();
 		bSolutionInvalidatedByDynamicObstacle = false;
 		bTargetLocationChanged = false;
+		TargetActor = nullptr;
 	}
 };
 
@@ -105,7 +108,7 @@ public:
 
 	// Behavior Tree Input:
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "DoN Navigation")
-	FBlackboardKeySelector FlightLocationKey;	
+	FBlackboardKeySelector FlightGoalKey;
 
 	/* Optional: Useful in somecases where you want failure or success of a task to automatically update a particular blackboard key*/
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "DoN Navigation")
@@ -164,6 +167,8 @@ protected:
 	void AbortPathfindingRequest(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory);
 
 	void TickPathNavigation(UBehaviorTreeComponent& OwnerComp, FBT_FlyToTarget* MyMemory, float DeltaSeconds);
+
+	bool CheckTargetMoved(FBT_FlyToTarget* MyMemory);
 
 	virtual void OnTaskFinished(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory, EBTNodeResult::Type TaskResult) override;
 

--- a/Source/DonAINavigation/Classes/BehaviorTree/BTTask_FlyTo.h
+++ b/Source/DonAINavigation/Classes/BehaviorTree/BTTask_FlyTo.h
@@ -63,12 +63,16 @@ struct FBT_FlyToTarget
 
 	AActor* TargetActor;
 
+	/* Whether this is a repath due to an actor target having moved */
+	bool isMovingTargetRepath = false;
+
 	FDelegateHandle BBObserverDelegateHandle;
 
 	uint32 bTargetLocationChanged : 1;
 
 	void Reset()
 	{	
+		isMovingTargetRepath = false;
 		solutionTraversalIndex = 0;
 		QueryResults = FDoNNavigationQueryData();
 		QueryParams = FDoNNavigationQueryParams();
@@ -162,7 +166,7 @@ protected:
 
 	FBT_FlyToTarget* TaskMemoryFromGenericPayload(void* GenericPayload);
 
-	EBTNodeResult::Type SchedulePathfindingRequest(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory);	
+	EBTNodeResult::Type SchedulePathfindingRequest(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory, bool isMovingTargetRepath = false);	
 
 	void AbortPathfindingRequest(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory);
 


### PR DESCRIPTION
This PR extends BTTask_FlyTo to accept Actors as well as Vectors in its target BlackBoard key. The system works by using the same UProperties that define if and how the task adapts to changes in Vector BlackBoard keys. On tick, if the target BlackBoard key is an Actor and has moved RecalculatePathTolerance from the current end of the path, BTTask_FlyTo calculates a new path to that actor's new location.

This ended up being useful in my game where AI creatures needed to follow the player around, as their b-trees didn't accommodate the multiple-node solution of the PursuitChaseBehavior example. I hope you find it useful as well!